### PR TITLE
move lambda function here

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ venv
 .vscode
 __pycache__
 log
+*.egg-info
+dist
+build

--- a/aws-lambda/README.md
+++ b/aws-lambda/README.md
@@ -1,0 +1,21 @@
+
+### About
+
+This is a Lambda function for running gdoc-dlx on an automated schedule. 
+
+### Deployment 
+
+This describes how to deploy this function to AWS Lambda using the Python library [python-lambda](https://pypi.org/project/python-lambda/). The files in this directory are the standard files necessary for deploying Python code to Lambda.
+
+AWS credentials must be configured in the deployment environment. 
+
+1. Navigate to this directory (`gdoc-api/aws-lambda`) 
+2. Make sure a virtual environment (venv) is activated.
+3. ```pip install -r requirements.txt```
+4. ```lambda deploy```
+
+Note that once the Lambda function is deployed, it will not run until it is "invoked". [Several methods exist to invoke the function](https://docs.aws.amazon.com/lambda/latest/dg/lambda-invocation.html).
+
+### Running the Lambda function locally (for development/testing purposes)
+
+```lambda invoke -v --event-file=event.json```

--- a/aws-lambda/config.yaml
+++ b/aws-lambda/config.yaml
@@ -1,0 +1,12 @@
+region: us-east-1
+
+function_name: gdoc-dlx
+handler: service.handler
+description: GDOC to DLX Periodic Task Runner
+runtime: python3.9
+role: service-role/gdoc-dlx-role-389djnm9
+timeout: 315
+
+# Build options
+build:
+  source_directories: lib # a comma delimited list of directories in your project root that contains source to package.

--- a/aws-lambda/event.json
+++ b/aws-lambda/event.json
@@ -1,0 +1,4 @@
+{
+    "duty_station": "NY",
+    "days_ago": 1
+}

--- a/aws-lambda/requirements.txt
+++ b/aws-lambda/requirements.txt
@@ -1,0 +1,2 @@
+../. # installs dlx-dl from the directory above
+python-lambda @ git+https://github.com/nficano/python-lambda@2f9f17a5c5993e65ee2b61d06f29ed5a6689d337

--- a/aws-lambda/service.py
+++ b/aws-lambda/service.py
@@ -1,0 +1,17 @@
+from gdoc_api.scripts import gdoc_dlx
+import sys, datetime
+
+def handler(event, context):
+    print(f"Processing {event}")
+    
+    for param in ['duty_station', 'days_ago']:    
+        if event.get(param) is None:
+            raise Exception(f'Event parameter "{param}" is required')
+    
+    today = datetime.date.today()
+    date = today - datetime.timedelta(days=event['days_ago'])
+    gdoc_dlx.run(station=event['duty_station'], date=date, recursive=True)
+
+    return {
+        'status_code': 200
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3
 cryptography
-git+https://github.com/dag-hammarskjold-library/dlx
+git+https://github.com/dag-hammarskjold-library/dlx@v1.4.1
+requests
 requests_oauthlib


### PR DESCRIPTION
Move the AWS Lambda function from its own code repo to this one, so we can leverage GitHub Actions to automatically deploy when we make a new release in this codebase.

Closes #18