### PR TITLE
use pip install as first line of testing

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies. This is a very basic test to make sure requirements are compatible with each other.
+# To do: implement tests with pytest for additional assurance
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    
+env:
+  DLX_REST_TESTING: True
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt


### PR DESCRIPTION
Until we have more robust pytests, we can use the installation of requirements as a heads-up in case an incompatible version update is suggested by dependabot. This usually signals that something in the supported versions of other libraries has changed or will change.