### PR TITLE
Support new gDoc API (Azure + UAT)

### DIFF
--- a/gdoc_api/scripts/gdoc_dlx.py
+++ b/gdoc_api/scripts/gdoc_dlx.py
@@ -9,7 +9,7 @@ def get_args():
     parser = ArgumentParser(prog='gdoc-dlx')
     
     r = parser.add_argument_group('required')
-    r.add_argument('--station', required=True, choices=['NY', 'GE', 'Vienna', 'Beirut', 'Bangkok'])
+    r.add_argument('--station', required=True, choices=['NY', 'GE', 'Vienna', 'Beirut', 'Bangkok', 'Nairobi'])
     r.add_argument('--date', required=True, help='YYYY-MM-DD')
 
     nr = parser.add_argument_group('not required')
@@ -22,7 +22,7 @@ def get_args():
     ssm = boto3.client('ssm')
     # Can be "qa" or "prod"
     env = os.getenv("GDOC_ENV", "qa")
-    print("Connecting to",env)
+    print("Connecting to GDOC:",env)
     
     def param(name):
         return ssm.get_parameter(Name=name)['Parameter']['Value']


### PR DESCRIPTION
Closes #43 

Updates the connection criteria in the Gdoc class to use the new Azure authentication endpoint and new API URL. Also provides some abstraction to allow parameters for different environments (qa, prod). Note: when we're ready for production, we can use the environment variable GDOC_ENV="prod". Currently it defaults to "qa".

To do: Update the gdoc_dlx_retro script to write to the UAT database when configured for "qa" and the production database when configured for "prod".

This needs adequate testing, which means we also need to create a test deployment where it can run. The gDoc QA API doesn't seem to have much data in it, so it's hard to test with that as an endpoint. But because we can update the parameters in SSM, we can set a hybrid configuration: production gDoc and UAT dlx-rest.