### PR TITLE
Test and fix args

### DIFF
--- a/gdoc_api/scripts/gdoc_dlx.py
+++ b/gdoc_api/scripts/gdoc_dlx.py
@@ -62,7 +62,7 @@ def process_kwargs(**kwargs):
     so they can be parsed by argparse"""
 
     sys.argv = [sys.argv[0]]
-    params = ('station', 'date', 'symbol', 'language', 'overwrite', 'rescursive', 'connection_string', 'database', 's3_bucket', 'save_as', 'data_only')
+    params = ('station', 'date', 'symbol', 'language', 'overwrite', 'recursive', 'connection_string', 'database', 's3_bucket', 'save_as', 'data_only')
 
     for param in ('station', 'date'):
         if param not in params:

--- a/gdoc_api/tests/test_script.py
+++ b/gdoc_api/tests/test_script.py
@@ -1,0 +1,25 @@
+import pytest
+from gdoc_api import Gdoc
+from gdoc_api.scripts import gdoc_dlx
+
+def test_args():
+    # Test that args provided to function call are correctly converted to
+    # sys.argv
+
+    params = ('station', 'date', 'symbol', 'language', 'overwrite', 'recursive', 'connection_string', 'database', 's3_bucket', 'save_as', 'data_only')
+    bools = ('recursive', 'overwrite', 'data_only')
+
+    kwargs = {
+        'station': 'NY',
+        'date': '1970-01-01',
+        'recursive': True,
+        'overwrite': False
+    }
+
+    args = gdoc_dlx.get_args(**kwargs)
+    
+    assert args.station == 'NY'
+    assert args.date == '1970-01-01'
+    assert args.recursive
+    assert not args.overwrite
+    assert not args.data_only


### PR DESCRIPTION
Fixes bug in argument handling.

Basic tests are implemented here, but the actual API call and response processing is not tested yet. Whether to mock the API, or test against the qa version remains an open question.

Closes #73 
Closes #23 