### PR TITLE
overwrite the lambda's requirements.txt to use the parent package's r…

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -33,6 +33,7 @@ jobs:
             IMAGE_TAG: latest
           run: |
             cd ./gdoc-dlx-lambda
+            echo "gdoc-api git+https://github.com/dag-hammarskjold-library/gdoc-api@${{github.ref}}" > requirements.txt
             docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
             echo "Pushing image to ECR..."
             docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
overwrite the lambda's requirements.txt to use the parent package's release tag/ref

Fixes #80 