### PR TITLE
Use moto for test fixtures

### DIFF
--- a/gdoc_api/tests/test_script.py
+++ b/gdoc_api/tests/test_script.py
@@ -1,6 +1,26 @@
 import pytest
 from gdoc_api import Gdoc
 from gdoc_api.scripts import gdoc_dlx
+from moto import mock_aws
+import boto3, os
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+@pytest.fixture(scope="function")
+def ssm_mock(aws_credentials):
+    with mock_aws():
+        ssm = boto3.client("ssm")
+        ssm.put_parameter(
+            Name="gdoc-qa-api-secrets",
+            Description="QA parameters for testing",
+            Value=""
+        )
+        yield ssm
+
 
 def test_args():
     # Test that args provided to function call are correctly converted to


### PR DESCRIPTION
Updates the python-tests.yml to use moto. This allow mocking up SSM and passing test credentials.